### PR TITLE
Use overall results from latest event as Home

### DIFF
--- a/src/output/html.js
+++ b/src/output/html.js
@@ -208,7 +208,7 @@ const writeStandingsHTML = (division, type, links) => {
     `./${outputPath}/website/${division.divisionName}-${type}-standings.html`,
     out
   );
-  if (!fs.existsSync(`./${outputPath}/website/index.html`)) {
+  if (!fs.existsSync(`./${outputPath}/website/index.html`) && leagueRef.league.useStandingsForHome) {
     fs.writeFileSync(`./${outputPath}/website/index.html`, out);
   }
 };
@@ -406,6 +406,9 @@ const writeDriverResultsHTML = (event, division, links, eventIndex) => {
     `./${outputPath}/website/${division.divisionName}-${eventIndex}-driver-results.html`,
     out
   );
+  if (division.divisionName == "overall" && leagueRef.league.useResultsForHome) {
+    fs.writeFileSync(`./${outputPath}/website/index.html`, out);
+  }
 };
 
 const addLinks = (links, name, type, displayName) => {


### PR DESCRIPTION
Adds the option to display the latest events Overall results as Home (index.js).

It sets up in initialState.js with
useResultsForHome: true